### PR TITLE
Update the way we handle dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build
 node_modules
 coverage
 package-lock.json
+.idea

--- a/package.json
+++ b/package.json
@@ -17,20 +17,24 @@
     "type": "git",
     "url": "git://github.com/Intsights/jfixtures.git"
   },
+  "dependencies": {
+    "acorn": "^8.8.1"
+  },
   "devDependencies": {
-    "@types/acorn": "^4.0.5",
+    "@types/acorn": "^4.0.6",
     "@types/jest": "^27.0.1",
     "@typescript-eslint/eslint-plugin": "^4.26.1",
     "@typescript-eslint/parser": "^4.27.0",
-    "acorn": "^7.4.1",
     "eslint": "^7.28.0",
     "eslint-plugin-import": "^2.23.4",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^3.4.0",
-    "jest": "^27.0.6",
-    "ts-jest": "^27.0.5",
     "ts-node-dev": "^2.0.0",
     "typescript": "^4.3.2"
+  },
+  "peerDependencies": {
+    "jest": "^27.0.6",
+    "ts-jest": "^27.0.5"
   },
   "bugs": {
     "url": "https://github.com/Intsights/jfixtures/issues"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jfixtures",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Intsights Jest Fixtures Library",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,10 @@
   "dependencies": {
     "acorn": "^8.8.1"
   },
+  "peerDependencies": {
+    "jest": "^27.0.6",
+    "ts-jest": "^27.0.5"
+  },
   "devDependencies": {
     "@types/acorn": "^4.0.6",
     "@types/jest": "^27.0.1",
@@ -31,10 +35,6 @@
     "eslint-plugin-prettier": "^3.4.0",
     "ts-node-dev": "^2.0.0",
     "typescript": "^4.3.2"
-  },
-  "peerDependencies": {
-    "jest": "^27.0.6",
-    "ts-jest": "^27.0.5"
   },
   "bugs": {
     "url": "https://github.com/Intsights/jfixtures/issues"

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,7 +67,7 @@ function register(fixture: Fn): void {
 function getParams(fn: Fn): string[] {
   let parsed: any;
   try {
-    parsed = acorn.parse(fn.toString());
+    parsed = acorn.parse(fn.toString(), { ecmaVersion: 2021 });
 
     return parsed.body[0].params.map((node: any) => node.name);
   } catch (error) {
@@ -75,14 +75,14 @@ function getParams(fn: Fn): string[] {
   }
 
   try {
-    parsed = acorn.parse(fn.toString());
+    parsed = acorn.parse(fn.toString(), { ecmaVersion: 2021 });
     return parsed.body[0].expression.params.map((node: any) => node.name);
   } catch (error) {
     //
   }
 
   try {
-    parsed = acorn.parse(`class Fixtures { ${fn.toString()} }`);
+    parsed = acorn.parse(`class Fixtures { ${fn.toString()} }`, { ecmaVersion: 2021 });
     return parsed.body[0].body.body[0].value.params.map(
       (node: any) => node.name
     );


### PR DESCRIPTION
The following changes were made:

- `acorn` is now part of the `dependencies` instead of being under `devDependencies`, the declared version will now be installed instead of relying on other packages to install it and create a version mismatch
- `acorn` was updated to its latest `8.8.1` version and the code was updated accordingly with the parser expecting an ES2021 code (instead of the previous default of ES2020).
- `jest` and `ts-jest` are now `peerDependencies` as `jfixtures` is a plugin for `jest` and requires a specific host version to work correctly